### PR TITLE
Fix cronjob

### DIFF
--- a/playbooks/templates/k8s/namespace/01_matomo-config-map.yml.j2
+++ b/playbooks/templates/k8s/namespace/01_matomo-config-map.yml.j2
@@ -252,8 +252,9 @@ data:
     #!/bin/sh
     MATOMO_GEOIP_PATH=/var/www/html/misc/DBIP-City.mmdb
     MATOMO_GEOIP_EXTERNAL_PATH=/opt/extra-content/geoip/DBIP-City.mmdb
+    rm -f MATOMO_GEOIP_PATH
     chmod +x /var/www/html/console ; cd /var/www/html/
     ./console core:archive
     if [ -f "$MATOMO_GEOIP_PATH" ]; then
       cp -f $MATOMO_GEOIP_PATH $MATOMO_GEOIP_EXTERNAL_PATH
-    fi
+    fi    

--- a/playbooks/templates/k8s/namespace/01_matomo-config-map.yml.j2
+++ b/playbooks/templates/k8s/namespace/01_matomo-config-map.yml.j2
@@ -252,7 +252,7 @@ data:
     #!/bin/sh
     MATOMO_GEOIP_PATH=/var/www/html/misc/DBIP-City.mmdb
     MATOMO_GEOIP_EXTERNAL_PATH=/opt/extra-content/geoip/DBIP-City.mmdb
-    rm -f MATOMO_GEOIP_PATH
+    rm -f $MATOMO_GEOIP_PATH
     chmod +x /var/www/html/console ; cd /var/www/html/
     ./console core:archive
     if [ -f "$MATOMO_GEOIP_PATH" ]; then

--- a/playbooks/templates/k8s/namespace/01_matomo-config-map.yml.j2
+++ b/playbooks/templates/k8s/namespace/01_matomo-config-map.yml.j2
@@ -257,4 +257,4 @@ data:
     ./console core:archive
     if [ -f "$MATOMO_GEOIP_PATH" ]; then
       cp -f $MATOMO_GEOIP_PATH $MATOMO_GEOIP_EXTERNAL_PATH
-    fi    
+    fi

--- a/playbooks/templates/k8s/namespace/03_matomo-archive-cronjob.yml.j2
+++ b/playbooks/templates/k8s/namespace/03_matomo-archive-cronjob.yml.j2
@@ -28,7 +28,7 @@ spec:
               mountPath: /entrypoint.sh
               subPath: entrypoint.sh
           containers:
-          - name: matomo
+          - name: matomo-cron
             image: {{ wai_matomo_image }}:{{ 'latest' if item == 'wai-stag' else wai_matomo_image_tag }}
             imagePullPolicy: {{ 'Always' if item == 'wai-stag' else 'IfNotPresent' }}
             command: ["sh", "-c", ". /entrypoint.sh"]


### PR DESCRIPTION
Modifica il nome del container da matomo a matomo-cron in modo da ricercarlo immediatamente nei log e risolve il problema di
```
cp: '/var/www/html/misc/DBIP-City.mmdb' and '/opt/extra-content/geoip/DBIP-City.mmdb' are the same file
```
rimuovendo il link simbolico prima che parta il `cron:archive`