### PR TITLE
Move from galera sst rsync to mariabackup

### DIFF
--- a/playbooks/roles/galera/tasks/main.yml
+++ b/playbooks/roles/galera/tasks/main.yml
@@ -5,11 +5,20 @@
     msg: "Wrong configuration for Galera cluster: less than 3 members found"
   when: "groups[group_names[0]] | length < 3"
 
-# - name: Galera .:. Install galera dependencies
-#   apt:
-#     update_cache: true
-#     name: galera-3
-#     state: present
+- name: Galera  .:. Test if prod password
+  set_fact:
+    wai_environment: wai-prod
+  when: inventory_hostname in groups['galera-prod'] or inventory_hostname in groups['galera-prod-slave']
+
+- name: Galera .:. Test if play password
+  set_fact:
+    wai_environment: wai-play
+  when: inventory_hostname in groups['galera-play']
+
+- name: Galera .:. Fail if password is not found
+  fail:
+    msg: "STS Password for the current environment not found"
+  when: "wai_environment is not defined or wai_database_credentials[wai_environment] is not defined"
 
 - name: Galera .:. Test if galera has been configured
   stat:
@@ -81,6 +90,17 @@
   when:
     - inventory_hostname == groups['galera-prod'][0]
 
+- name: Galera .:. Create sst replication user on production master primary node
+  mysql_user:
+    login_user: "root"
+    name: "{{ wai_database_credentials['wai-prod']['sst-user-username'] }}"
+    password: "{{ wai_database_credentials['wai-prod']['sst-user-password'] }}"
+    priv: "*.*:RELOAD, PROCESS, LOCK TABLES, REPLICATION CLIENT"
+    host: "localhost"
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+  when:
+    - inventory_hostname == groups['galera-prod'][0]
+    
 - name: Galera .:. Activate replica on production slave primary node
   mysql_replication:
     mode: changemaster

--- a/playbooks/roles/galera/templates/galera.yml.j2
+++ b/playbooks/roles/galera/templates/galera.yml.j2
@@ -17,6 +17,7 @@ server_id=02
 # Configure settings for replication
 server_id=01
 log_bin = /opt/data/mysql-binlog/binlog
+log_bin_index = /opt/data/mysql-binlog/binlog.index
 log_slave_updates = ON
 expire_logs_days = 7
 gtid-domain-id = 1
@@ -35,7 +36,8 @@ wsrep_cluster_name="wai-galera_cluster"
 wsrep_cluster_address="gcomm://{{ groups[current_group_name] | map("extract", hostvars, ["ansible_default_ipv4", "address"]) | join(',') }}"
 
 # Galera Synchronization Configuration
-wsrep_sst_method=rsync
+wsrep_sst_method = mariabackup
+wsrep_sst_auth = {{ wai_database_credentials[wai_environment]['sst-user-username'] }}:{{ wai_database_credentials[wai_environment]['sst-user-password'] }}
 
 # Galera Node Configuration
 wsrep_node_address="{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"

--- a/playbooks/roles/mariadb/tasks/main.yml
+++ b/playbooks/roles/mariadb/tasks/main.yml
@@ -35,9 +35,13 @@
 - name: MariaDB .:. Install MariaDB
   apt:
     update_cache: false
-    name: "mariadb-server-{{ mariadb_version }}"
+    name: "{{ item }}"
     state: present
   when: mariadb_mycnf_result.stat.exists == false
+  with_items:
+    - "mariadb-server-{{ mariadb_version }}"
+    - socat
+    - mariadb-backup
 
 - name: MariaDB .:. Configure bind address
   replace:

--- a/playbooks/secrets.yml
+++ b/playbooks/secrets.yml
@@ -187,6 +187,8 @@ wai_database_credentials:
     wai-admin-password: changeme
     replica-user-username: replica-user
     replica-user-password: changeme
+    sst-user-username: sst-user
+    sst-user-password: changeme
   wai-play:
     root: changeme
     matomo-admin-username: matomo-admin
@@ -197,6 +199,8 @@ wai_database_credentials:
     wai-admin-password: changeme
     replica-user-username: replica-user
     replica-user-password: changeme
+    sst-user-username: sst-user
+    sst-user-password: changeme
   wai-stag:
     root: changeme
     matomo-admin-username: matomo-admin


### PR DESCRIPTION
Use mariabackup sst_method to avoid lock on database tables during galera crash recovery 