### PR TITLE
Fix issue #186

### DIFF
--- a/playbooks/k8s-helm-charts.yml
+++ b/playbooks/k8s-helm-charts.yml
@@ -430,6 +430,7 @@
                 cpu: 100m
                 memory: 128Mi
           master:
+            disableCommands: "{{ ['FLUSHDB', 'FLUSHALL'] if item[0] == 'wai-prod' else []}}"
             persistence:
               enabled: true
               storageClass: storage-heketi


### PR DESCRIPTION
L'impostazione configurata solamente su IPA redis search perchè già presente su application-redis ed ingestion-redis.
Comandi disabilitati manualmente nelle configmap di wai-stag e wai-play.
